### PR TITLE
Fix underscore replacement in receipt prompt

### DIFF
--- a/src/services/receiptService.js
+++ b/src/services/receiptService.js
@@ -86,7 +86,7 @@ class ReceiptService {
       throw new Error(`Unsupported receipt type: ${receiptType}`);
     }
 
-    const prompt = `Please extract information from this ${receiptType.replace('_', ' ')} receipt image and fill in the provided JSON format.`;
+    const prompt = `Please extract information from this ${receiptType.replace(/_/g, ' ')} receipt image and fill in the provided JSON format.`;
     
     try {
       const results = await this.llmProvider.processImage(imageBuffer, prompt, template);


### PR DESCRIPTION
## Summary
- ensure all underscores are replaced with spaces when building prompts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bd2e8c79c8328853b4f601f31cfa7