### PR TITLE
Add count to process endpoint response

### DIFF
--- a/src/routes/receipts.js
+++ b/src/routes/receipts.js
@@ -35,6 +35,7 @@ router.post('/process', rateLimiter(), upload.single('image'), processImage, val
       success: true,
       data: result.data,
       receiptType: result.receiptType,
+      count: result.count,
       imageSize: req.file.size,
       processedAt: new Date().toISOString()
     });


### PR DESCRIPTION
## Summary
- expose the `count` field from `ReceiptService.processReceipt` in the `/process` route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bd645663083288781ecbe5eb76e39