### PR TITLE
Add Jest tests and health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ A Node.js backend service that processes receipt images using Google Gemini LLM 
 
 6. Open http://localhost:3000 in your browser
 
+### Running Tests
+
+Run the Jest test suite with:
+
+```bash
+npm test
+```
+
 ## API Endpoints
 
 - `GET /api/receipts/types` - Get available receipt types and templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "sharp": "^0.32.6"
       },
       "devDependencies": {
-        "nodemon": "^3.0.2"
+        "nodemon": "^3.0.2",
+        "jest": "^29.6.4",
+        "supertest": "^6.3.3"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -17,7 +17,9 @@
     "sharp": "^0.32.6"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "jest": "^29.6.4",
+    "supertest": "^6.3.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/server.js
+++ b/src/server.js
@@ -53,12 +53,16 @@ app.use((error, req, res, next) => {
   });
 });
 
-// Start server
+// Start server only when this file is executed directly
 const PORT = config.port;
 const HOST = process.env.HOST || '0.0.0.0';
 
-app.listen(PORT, HOST, () => {
-  console.log(`Server running on ${HOST}:${PORT}`);
-  console.log(`API available at http://${HOST}:${PORT}/api`);
-  console.log(`Frontend available at http://${HOST}:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, HOST, () => {
+    console.log(`Server running on ${HOST}:${PORT}`);
+    console.log(`API available at http://${HOST}:${PORT}/api`);
+    console.log(`Frontend available at http://${HOST}:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../src/server');
+
+describe('GET /health', () => {
+  it('responds with success true', async () => {
+    const res = await request(app).get('/health');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest as dev dependencies
- export the Express app so Jest can import it
- create a health check test
- document testing in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd83ff6c8328b0e83ca809591d6c